### PR TITLE
docs: Add AWS disclaimer section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # intelligent-request-collector
 
 **Disclaimers**
+
 Customers are responsible for making their own independent assessment of the information in this document.
 
 This document:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # intelligent-request-collector
 
+**Disclaimers**
+Customers are responsible for making their own independent assessment of the information in this document.
+
+This document:
+
+(a) is for informational purposes only,
+
+(b) references AWS product offerings and practices, which are subject to change without notice,
+
+(c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. AWS products or services are provided "as is" without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers, and
+
+(d) is not to be considered a recommendation or viewpoint of AWS.
+
+Additionally, you are solely responsible for testing, security and optimizing all code and assets on GitHub repo, and all such code and assets should be considered:
+
+(a) as-is and without warranties or representations of any kind,
+
+(b) not suitable for production environments, or on production or other critical data, and
+
+(c) to include shortcuts in order to support rapid prototyping such as, but not limited to, relaxed authentication and authorization and a lack of strict adherence to security best practices.
+
+All work produced is open source. More information can be found in the GitHub repo.
+
 **Prerequisites**
 
 1) Make sure there is a valid internet gateway and VPC set up.
@@ -112,29 +135,6 @@ echo "To reattach to the Streamlit session, run: screen -r my_streamlit_app"
    ```
    cat .env
    ```
-
-## Disclaimers
-Customers are responsible for making their own independent assessment of the information in this document.
-
-This document:
-
-(a) is for informational purposes only,
-
-(b) references AWS product offerings and practices, which are subject to change without notice,
-
-(c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. AWS products or services are provided "as is" without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers, and
-
-(d) is not to be considered a recommendation or viewpoint of AWS.
-
-Additionally, you are solely responsible for testing, security and optimizing all code and assets on GitHub repo, and all such code and assets should be considered:
-
-(a) as-is and without warranties or representations of any kind,
-
-(b) not suitable for production environments, or on production or other critical data, and
-
-(c) to include shortcuts in order to support rapid prototyping such as, but not limited to, relaxed authentication and authorization and a lack of strict adherence to security best practices.
-
-All work produced is open source. More information can be found in the GitHub repo.
 
 ## Your setup is now complete
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ echo "To reattach to the Streamlit session, run: screen -r my_streamlit_app"
    cat .env
    ```
 
+## Disclaimers
+Customers are responsible for making their own independent assessment of the information in this document.
+
+This document:
+
+(a) is for informational purposes only,
+
+(b) references AWS product offerings and practices, which are subject to change without notice,
+
+(c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. AWS products or services are provided "as is" without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers, and
+
+(d) is not to be considered a recommendation or viewpoint of AWS.
+
+Additionally, you are solely responsible for testing, security and optimizing all code and assets on GitHub repo, and all such code and assets should be considered:
+
+(a) as-is and without warranties or representations of any kind,
+
+(b) not suitable for production environments, or on production or other critical data, and
+
+(c) to include shortcuts in order to support rapid prototyping such as, but not limited to, relaxed authentication and authorization and a lack of strict adherence to security best practices.
+
+All work produced is open source. More information can be found in the GitHub repo.
+
 ## Your setup is now complete
 
 **Note:** The rest of the documentations provides commands to manage any Screen/Streamlit sessions


### PR DESCRIPTION
Summary
This PR adds the required AWS disclaimer section to the README.

The disclaimer has been placed after the introductory content and before the next section, as per the standard format used across ASUCICREPO repositories.

Changes
Added AWS disclaimer section to README
For repos without README: Created new README.md with disclaimer
Disclaimer Content
The disclaimer informs users that:

This document is for informational purposes only
AWS products/services are provided "as is"
Prototype code should be considered as-is and not suitable for production
Code may include shortcuts for rapid prototyping
🤖 Generated by automated disclaimer update script